### PR TITLE
Switch to grunt-bump in order to keep bower.json in sync

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "bower_components"
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -73,9 +73,13 @@ module.exports = function(grunt) {
       src: ['**']
     },
 
-    release: {
+    bump: {
       options: {
-        npm: false, //default: true
+        files: ['package.json', 'bower.json'],
+        commitFiles: ['package.json', 'bower.json'],
+        tagName: '%VERSION%',
+        commitMessage: 'version %VERSION%',
+        pushTo: 'origin'
       }
     }
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -51,7 +51,7 @@ module.exports = function(grunt) {
         cmd: 'bower update'
       },
       kss: {
-        cmd: 'kss-node sass/ docs/ -sass css/wyrm_test.css --template docs_template'
+        cmd: 'node_modules/.bin/kss-node sass/ docs/ -sass css/wyrm_test.css --template docs_template'
       }
     },
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "wyrm",
-  "version": "0.0.2",
+  "version": "0.0.174",
   "homepage": "https://github.com/snide/wyrm",
   "authors": [
     "Dave Snider <dave.snider@gmail.com>"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "matchdep": "~0.1.2",
     "grunt-gh-pages": "~0.9.0",
     "grunt-bump": "~0.0.13",
-    "grunt-open": "~0.2.3"
+    "grunt-open": "~0.2.3",
+    "kss": "~0.3.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "grunt-contrib-copy": "0.4.1",
     "matchdep": "~0.1.2",
     "grunt-gh-pages": "~0.9.0",
-    "grunt-bump": "~0.0.13"
+    "grunt-bump": "~0.0.13",
+    "grunt-open": "~0.2.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "grunt-contrib-connect": "0.5.0",
     "grunt-contrib-copy": "0.4.1",
     "matchdep": "~0.1.2",
-    "grunt-release": "~0.6.0",
-    "grunt-gh-pages": "~0.9.0"
+    "grunt-gh-pages": "~0.9.0",
+    "grunt-bump": "~0.0.13"
   }
 }


### PR DESCRIPTION
The version in `bower.json` doesn't get updated by grunt-release so I got this warning when installing:
```
bower wyrm#*    mismatch Version declared in the json (0.0.2) is different than the resolved one (0.0.174)
```

I swapped grunt-release out for [grunt-bump](https://github.com/vojtajina/grunt-bump) because it allows you to specify multiple files to bump. I think I replicated the default configuration of grunt-release, but there might be some differences.